### PR TITLE
fix: LLVM 7.0 code on AARCH64 due to the _Float16 related issue

### DIFF
--- a/libcxx/include/type_traits
+++ b/libcxx/include/type_traits
@@ -736,8 +736,14 @@ template <class _Tp> struct __libcpp_is_floating_point              : public fal
 #ifdef __clang__
 template <>          struct __libcpp_is_floating_point<__fp16>      : public true_type {};
 #endif
-#ifdef __FLT16_MANT_DIG__
+#ifdef __aarch64__
+  #ifdef __STDC_WANT_IEC_60559_TYPES_EXT__
 template <>          struct __libcpp_is_floating_point<_Float16>    : public true_type {};
+  #endif
+#else
+  #ifdef __FLT16_MANT_DIG__
+template <>          struct __libcpp_is_floating_point<_Float16>    : public true_type {};
+  #endif
 #endif
 template <>          struct __libcpp_is_floating_point<float>       : public true_type {};
 template <>          struct __libcpp_is_floating_point<double>      : public true_type {};

--- a/libcxx/test/libcxx/type_traits/is_floating_point.pass.cpp
+++ b/libcxx/test/libcxx/type_traits/is_floating_point.pass.cpp
@@ -17,8 +17,14 @@ int main() {
 #ifdef __clang__
   static_assert(std::is_floating_point<__fp16>::value, "");
 #endif
-#ifdef __FLT16_MANT_DIG__
+#ifdef __aarch64__
+  #ifdef __STDC_WANT_IEC_60559_TYPES_EXT__
   static_assert(std::is_floating_point<_Float16>::value, "");
+  #endif
+#else
+  #ifdef __FLT16_MANT_DIG__
+  static_assert(std::is_floating_point<_Float16>::value, "");
+  #endif
 #endif
   return 0;
 }


### PR DESCRIPTION
As discussed here: https://bugs.llvm.org/show_bug.cgi?id=37668
Changes only effects AARCH64 arch.